### PR TITLE
Move a few more functions into namespaces, remove `TConfiguration` template parameter

### DIFF
--- a/Common/GTesting/elxImpactMetricGTest.cxx
+++ b/Common/GTesting/elxImpactMetricGTest.cxx
@@ -6,6 +6,10 @@
 #include <sstream>
 #include "itkParameterMapInterface.h"
 
+using elx::formatParameterStringByDimensionAndLevel;
+using elx::GetBooleanVectorFromString;
+using elx::GetVectorFromString;
+using elx::groupStrByDimensions;
 
 namespace
 {

--- a/Common/GTesting/elxImpactMetricGTest.cxx
+++ b/Common/GTesting/elxImpactMetricGTest.cxx
@@ -103,18 +103,15 @@ GTEST_TEST(FormatParameterStringByDimensionAndLevel, Basic)
   config->Initialize(argMap, parameterMap);
 
   // Level 0: read 3 individual values → expect "5 5 5"
-  std::string resultStr =
-    formatParameterStringByDimensionAndLevel<elastix::Configuration>(config.GetPointer(), "Impact", "PatchSize", 0, 3);
+  std::string resultStr = formatParameterStringByDimensionAndLevel(config.GetPointer(), "Impact", "PatchSize", 0, 3);
   EXPECT_EQ(resultStr, "5 5 5");
 
   // Level 1: one line with 5 values → "11 11 11 29 29"
-  resultStr =
-    formatParameterStringByDimensionAndLevel<elastix::Configuration>(config.GetPointer(), "Impact", "PatchSize", 1, 3);
+  resultStr = formatParameterStringByDimensionAndLevel(config.GetPointer(), "Impact", "PatchSize", 1, 3);
   EXPECT_EQ(resultStr, "11 11 11 29 29");
 
   // Level 2: only "13" twice → expect fallback to fill 3 values
-  resultStr =
-    formatParameterStringByDimensionAndLevel<elastix::Configuration>(config.GetPointer(), "Impact", "PatchSize", 2, 3);
+  resultStr = formatParameterStringByDimensionAndLevel(config.GetPointer(), "Impact", "PatchSize", 2, 3);
   EXPECT_EQ(resultStr, "13 13");
 
   // --- Second case: PatchSize as float ---
@@ -123,13 +120,11 @@ GTEST_TEST(FormatParameterStringByDimensionAndLevel, Basic)
   config->Initialize(argMap, parameterMap);
 
   // Level 0: two values → repeat to fill 3
-  resultStr =
-    formatParameterStringByDimensionAndLevel<elastix::Configuration>(config.GetPointer(), "Impact", "PatchSize", 0, 3);
+  resultStr = formatParameterStringByDimensionAndLevel(config.GetPointer(), "Impact", "PatchSize", 0, 3);
   EXPECT_EQ(resultStr, "6.0 6.0");
 
   // Level 1: only "1.0 1.0"
-  resultStr =
-    formatParameterStringByDimensionAndLevel<elastix::Configuration>(config.GetPointer(), "Impact", "PatchSize", 1, 3);
+  resultStr = formatParameterStringByDimensionAndLevel(config.GetPointer(), "Impact", "PatchSize", 1, 3);
   EXPECT_EQ(resultStr, "1.0 1.0");
 
   // --- Third case: all entries are "6.0", just checking fallback filling ---
@@ -137,17 +132,14 @@ GTEST_TEST(FormatParameterStringByDimensionAndLevel, Basic)
   parameterMap["ImpactPatchSize"] = { "6.0", "6.0", "6.0", "6.0", "3.0 3.0 1.5 1.5 1.5", "1.0", "1.0" };
   config->Initialize(argMap, parameterMap);
 
-  resultStr =
-    formatParameterStringByDimensionAndLevel<elastix::Configuration>(config.GetPointer(), "Impact", "PatchSize", 0, 3);
+  resultStr = formatParameterStringByDimensionAndLevel(config.GetPointer(), "Impact", "PatchSize", 0, 3);
   EXPECT_EQ(resultStr, "6.0 6.0 6.0");
 
   // Check fallback with single value
-  resultStr =
-    formatParameterStringByDimensionAndLevel<elastix::Configuration>(config.GetPointer(), "Impact", "PatchSize", 1, 3);
+  resultStr = formatParameterStringByDimensionAndLevel(config.GetPointer(), "Impact", "PatchSize", 1, 3);
   EXPECT_EQ(resultStr, "6.0");
 
-  resultStr =
-    formatParameterStringByDimensionAndLevel<elastix::Configuration>(config.GetPointer(), "Impact", "PatchSize", 2, 3);
+  resultStr = formatParameterStringByDimensionAndLevel(config.GetPointer(), "Impact", "PatchSize", 2, 3);
   EXPECT_EQ(resultStr, "1.0 1.0");
 
   // --- Fourth case: test imageDimension auto-detection via ImpactDimension ---
@@ -156,16 +148,13 @@ GTEST_TEST(FormatParameterStringByDimensionAndLevel, Basic)
   parameterMap["ImpactPatchSize"] = { "5", "5", "13", "13", "13", "11 11 11 29 29" };
   config->Initialize(argMap, parameterMap);
 
-  resultStr =
-    formatParameterStringByDimensionAndLevel<elastix::Configuration>(config.GetPointer(), "Impact", "PatchSize", 0);
+  resultStr = formatParameterStringByDimensionAndLevel(config.GetPointer(), "Impact", "PatchSize", 0);
   EXPECT_EQ(resultStr, "5 5");
 
-  resultStr =
-    formatParameterStringByDimensionAndLevel<elastix::Configuration>(config.GetPointer(), "Impact", "PatchSize", 1);
+  resultStr = formatParameterStringByDimensionAndLevel(config.GetPointer(), "Impact", "PatchSize", 1);
   EXPECT_EQ(resultStr, "13 13 13");
 
-  resultStr =
-    formatParameterStringByDimensionAndLevel<elastix::Configuration>(config.GetPointer(), "Impact", "PatchSize", 2);
+  resultStr = formatParameterStringByDimensionAndLevel(config.GetPointer(), "Impact", "PatchSize", 2);
   EXPECT_EQ(resultStr, "11 11 11 29 29");
 }
 
@@ -180,8 +169,7 @@ GTEST_TEST(FormatParameterStringByDimensionAndLevel, EarlyStopDueToMissingParam)
   parameterMap["ImpactPatchSize"] = { "5", "5" };
   config->Initialize(argMap, parameterMap);
 
-  std::string resultStr =
-    formatParameterStringByDimensionAndLevel<elastix::Configuration>(config.GetPointer(), "Impact", "PatchSize", 0, 3);
+  std::string resultStr = formatParameterStringByDimensionAndLevel(config.GetPointer(), "Impact", "PatchSize", 0, 3);
 
   // Should stop early and return "5 5" (not enough to fill 3)
   EXPECT_EQ(resultStr, "5 5");
@@ -196,7 +184,7 @@ GTEST_TEST(FormatParameterStringByDimensionAndLevel, LevelBeyondAvailable)
   parameterMap["ImpactPatchSize"] = { "5", "5" }; // Only 2 values
   config->Initialize(argMap, parameterMap);
 
-  std::string resultStr = formatParameterStringByDimensionAndLevel<elastix::Configuration>(
-    config.GetPointer(), "Impact", "PatchSize", 5, 3); // ask level 5
+  std::string resultStr =
+    formatParameterStringByDimensionAndLevel(config.GetPointer(), "Impact", "PatchSize", 5, 3); // ask level 5
   EXPECT_EQ(resultStr, "");
 }

--- a/Common/GTesting/elxImpactMetricGTest.cxx
+++ b/Common/GTesting/elxImpactMetricGTest.cxx
@@ -6,6 +6,9 @@
 #include <sstream>
 #include "itkParameterMapInterface.h"
 
+
+namespace
+{
 // Helper to format vector outputs
 template <typename T>
 std::string
@@ -25,6 +28,7 @@ ExpectVectorEqual(const std::vector<T> & actual, const std::vector<T> & expected
 {
   EXPECT_EQ(actual, expected) << "Expected: " << vecToStr(expected) << "\nActual:   " << vecToStr(actual);
 }
+} // namespace
 
 
 GTEST_TEST(GetVectorFromString, LimitsAndParsing)

--- a/Components/Metrics/Impact/elxImpactMetric.h
+++ b/Components/Metrics/Impact/elxImpactMetric.h
@@ -20,6 +20,7 @@
 #define elxImpactMetric_h
 
 #include "elxIncludes.h" // include first to avoid MSVS warning
+#include "elxConfiguration.h"
 #include "itkImpactImageToImageMetric.h"
 #include "itkVector.h"
 
@@ -479,19 +480,17 @@ groupStrByDimensions(std::string valueStr, std::vector<unsigned int> dimensions)
  * The output collects parameters for the requested level. If a value at that level
  * contains multiple space-separated entries, it is returned directly.
  *
- * \tparam TConfiguration Type of the configuration (must provide ReadParameter).
  * \param config Pointer to configuration object.
  * \param prefix Parameter prefix (e.g., "Impact").
  * \param parameterName Name of the parameter suffix (e.g., "PatchSize").
  * \param level Level index to extract values from.
  * \return Formatted string containing values.
  */
-template <typename TConfiguration>
-std::string
-formatParameterStringByDimensionAndLevel(const TConfiguration * config,
-                                         const std::string &    prefix,
-                                         const std::string &    parameterName,
-                                         int                    level)
+inline std::string
+formatParameterStringByDimensionAndLevel(const Configuration * config,
+                                         const std::string &   prefix,
+                                         const std::string &   parameterName,
+                                         int                   level)
 {
   std::ostringstream paramStream;
   std::ostringstream paramDefault;
@@ -545,7 +544,6 @@ formatParameterStringByDimensionAndLevel(const TConfiguration * config,
  *
  * Similar to the above function but uses a constant dimension instead of a per-level model dimension.
  *
- * \tparam TConfiguration Type of the configuration (must provide ReadParameter).
  * \param config Pointer to configuration object.
  * \param prefix Parameter prefix (e.g., "Impact").
  * \param parameterName Name of the parameter (e.g., "PatchSize").
@@ -553,13 +551,12 @@ formatParameterStringByDimensionAndLevel(const TConfiguration * config,
  * \param dimension Fixed dimension used to select parameters.
  * \return Formatted string containing values.
  */
-template <typename TConfiguration>
-std::string
-formatParameterStringByDimensionAndLevel(const TConfiguration * config,
-                                         const std::string &    prefix,
-                                         const std::string &    parameterName,
-                                         int                    level,
-                                         unsigned int           dimension)
+inline std::string
+formatParameterStringByDimensionAndLevel(const Configuration * config,
+                                         const std::string &   prefix,
+                                         const std::string &   parameterName,
+                                         int                   level,
+                                         unsigned int          dimension)
 {
   std::ostringstream paramStream;
   int                paramIndex = 0;

--- a/Components/Metrics/Impact/elxImpactMetric.h
+++ b/Components/Metrics/Impact/elxImpactMetric.h
@@ -261,8 +261,6 @@ private:
   GenerateModelsConfiguration(unsigned int level, std::string type, std::string mode, unsigned int imageDimension);
 };
 
-} // end namespace elastix
-
 /**
  * \brief Convert a string token to a typed value with bounds checking.
  *
@@ -605,6 +603,8 @@ formatParameterStringByDimensionAndLevel(const TConfiguration * config,
 
   return paramStream.str();
 } // end formatParameterStringByDimensionAndLevel
+
+} // end namespace elastix
 
 
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/Components/Metrics/Impact/elxImpactMetric.hxx
+++ b/Components/Metrics/Impact/elxImpactMetric.hxx
@@ -111,25 +111,23 @@ ImpactMetric<TElastix>::GenerateModelsConfiguration(unsigned int level,
   std::vector<unsigned int> dimensions;
   if (mode == "Static")
   {
-    patchSizeStr = formatParameterStringByDimensionAndLevel<Configuration>(
-      this->GetConfiguration(), prefix, "PatchSize", level, imageDimension);
+    patchSizeStr =
+      formatParameterStringByDimensionAndLevel(this->GetConfiguration(), prefix, "PatchSize", level, imageDimension);
     for (int i = 0; i < modelsPathVec.size(); ++i)
       dimensions.push_back(imageDimension);
     if (patchSizeStr.empty() && level > 0)
     {
-      patchSizeStr = formatParameterStringByDimensionAndLevel<Configuration>(
-        this->GetConfiguration(), prefix, "PatchSize", 0, imageDimension);
+      patchSizeStr =
+        formatParameterStringByDimensionAndLevel(this->GetConfiguration(), prefix, "PatchSize", 0, imageDimension);
     }
   }
   else
   {
-    patchSizeStr =
-      formatParameterStringByDimensionAndLevel<Configuration>(this->GetConfiguration(), prefix, "PatchSize", level);
+    patchSizeStr = formatParameterStringByDimensionAndLevel(this->GetConfiguration(), prefix, "PatchSize", level);
     dimensions = modelsDimensionVec;
     if (patchSizeStr.empty() && level > 0)
     {
-      patchSizeStr =
-        formatParameterStringByDimensionAndLevel<Configuration>(this->GetConfiguration(), prefix, "PatchSize", 0);
+      patchSizeStr = formatParameterStringByDimensionAndLevel(this->GetConfiguration(), prefix, "PatchSize", 0);
     }
   }
   std::vector<std::string> patchSizeVec = groupStrByDimensions(patchSizeStr, dimensions);
@@ -138,8 +136,8 @@ ImpactMetric<TElastix>::GenerateModelsConfiguration(unsigned int level,
   std::vector<std::string> voxelSizeVec;
   if (mode == "Static")
   {
-    voxelSizeStr = formatParameterStringByDimensionAndLevel<Configuration>(
-      this->GetConfiguration(), prefix, "VoxelSize", level, imageDimension);
+    voxelSizeStr =
+      formatParameterStringByDimensionAndLevel(this->GetConfiguration(), prefix, "VoxelSize", level, imageDimension);
     std::vector<unsigned int> imageDimensions;
     for (int i = 0; i < modelsPathVec.size(); ++i)
       imageDimensions.push_back(imageDimension);
@@ -147,8 +145,7 @@ ImpactMetric<TElastix>::GenerateModelsConfiguration(unsigned int level,
   }
   else
   {
-    voxelSizeStr =
-      formatParameterStringByDimensionAndLevel<Configuration>(this->GetConfiguration(), prefix, "VoxelSize", level);
+    voxelSizeStr = formatParameterStringByDimensionAndLevel(this->GetConfiguration(), prefix, "VoxelSize", level);
     voxelSizeVec = groupStrByDimensions(voxelSizeStr, modelsDimensionVec);
   }
 


### PR DESCRIPTION
@vboussot Hereby three small style improvements, please correct me if I'm wrong  😃 

- Moved helper functions of elxImpactMetricGTest into an unnamed namespace, following C++ Core Guidelines, ["Use an unnamed (anonymous) namespace for all internal/non-exported entities"](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf22-use-an-unnamed-anonymous-namespace-for-all-internalnon-exported-entities)
- Moved elxImpactMetric functions from out of the global namespace into the `elastix` namespace, to reduce the chance of name collisions
- Removed `TConfiguration` template parameters from formatParameterStringByDimensionAndLevel, because elastix only has one `Configuration` type
