### PR TITLE
STYLE: Move definition of `ModelConfiguration` into its own header file

### DIFF
--- a/Components/Metrics/Impact/CMakeLists.txt
+++ b/Components/Metrics/Impact/CMakeLists.txt
@@ -9,4 +9,5 @@ ADD_ELXCOMPONENT(ImpactMetric USE_TORCH
  itkBSplineInterpolateVectorImageFunction.hxx
  itkImpactImageToImageMetric.h
  itkImpactImageToImageMetric.hxx
+ itkImpactModelConfiguration.h
  )

--- a/Components/Metrics/Impact/ImpactTensorUtils.h
+++ b/Components/Metrics/Impact/ImpactTensorUtils.h
@@ -37,6 +37,7 @@
 #include <functional>
 #include <exception>
 #include "ImpactLoss.h"
+#include "itkImpactModelConfiguration.h"
 #include <random>
 
 namespace ImpactTensorUtils
@@ -67,16 +68,12 @@ TensorToImage(typename TImage::ConstPointer image, torch::Tensor layers);
  * \param writeInputImage Optional function to export resampled input for debugging.
  * \return Vector of ITK feature images, one per layer and model.
  */
-template <typename TImage,
-          typename FeaturesMaps,
-          typename InterpolatorType,
-          typename ModelConfiguration,
-          typename FeaturesImageType>
+template <typename TImage, typename FeaturesMaps, typename InterpolatorType, typename FeaturesImageType>
 std::vector<FeaturesMaps>
 GetFeaturesMaps(
   typename TImage::ConstPointer                                                                    image,
   typename InterpolatorType::Pointer                                                               interpolator,
-  const std::vector<ModelConfiguration> &                                                          modelsConfiguration,
+  const std::vector<itk::ImpactModelConfiguration> &                                               modelsConfiguration,
   torch::Device                                                                                    device,
   std::vector<unsigned int>                                                                        pca,
   std::vector<torch::Tensor> &                                                                     principal_components,
@@ -91,20 +88,18 @@ GetFeaturesMaps(
  *
  * Called during initialization to ensure models are properly loaded and executable.
  */
-template <typename ModelConfiguration>
 std::vector<torch::Tensor>
-GetModelOutputsExample(std::vector<ModelConfiguration> & modelsConfig,
-                       const std::string &               modelType,
-                       torch::Device                     device);
+GetModelOutputsExample(std::vector<itk::ImpactModelConfiguration> & modelsConfig,
+                       const std::string &                          modelType,
+                       torch::Device                                device);
 
 /**
  * \brief Computes patch index offsets around a center point based on model config.
  *
  * This is used to extract local neighborhoods for each model (e.g., 5x5x5 patch).
  */
-template <typename ModelConfiguration>
 std::vector<std::vector<float>>
-GetPatchIndex(ModelConfiguration modelConfiguration, std::mt19937 & randomGenerator, unsigned int dimension);
+GetPatchIndex(itk::ImpactModelConfiguration modelConfiguration, std::mt19937 & randomGenerator, unsigned int dimension);
 
 template <typename ImagePointType>
 using ImagesPatchValuesEvaluator = std::function<
@@ -119,9 +114,9 @@ using ImagesPatchValuesEvaluator = std::function<
  *
  * \param evaluator  Callable to produce a tensor from a point + patch + subset
  */
-template <class ModelConfiguration, class ImagePointType>
+template <class ImagePointType>
 std::vector<torch::Tensor>
-GenerateOutputs(const std::vector<ModelConfiguration> &                               modelConfig,
+GenerateOutputs(const std::vector<itk::ImpactModelConfiguration> &                    modelConfig,
                 const std::vector<ImagePointType> &                                   fixedPoints,
                 const std::vector<std::vector<std::vector<std::vector<float>>>> &     patchIndex,
                 const std::vector<torch::Tensor>                                      subsetsOfFeatures,
@@ -143,9 +138,9 @@ using ImagesPatchValuesAndJacobiansEvaluator = std::function<torch::Tensor(const
  * \param evaluator Callable that returns a pair (features, jacobian) from a point.
  * \param losses    Mutable references to per-layer loss objects (updated incrementally).
  */
-template <typename ModelConfiguration, typename ImagePointType>
+template <typename ImagePointType>
 std::vector<torch::Tensor>
-GenerateOutputsAndJacobian(const std::vector<ModelConfiguration> &                           modelConfig,
+GenerateOutputsAndJacobian(const std::vector<itk::ImpactModelConfiguration> &                modelConfig,
                            const std::vector<ImagePointType> &                               fixedPoints,
                            const std::vector<std::vector<std::vector<std::vector<float>>>> & patchIndex,
                            std::vector<torch::Tensor>                                        subsetsOfFeatures,

--- a/Components/Metrics/Impact/ImpactTensorUtils.hxx
+++ b/Components/Metrics/Impact/ImpactTensorUtils.hxx
@@ -307,16 +307,12 @@ pca_transform(torch::Tensor input, torch::Tensor principal_components)
 /**
  * ******************* GetFeaturesMaps ***********************
  */
-template <typename TImage,
-          typename FeaturesMaps,
-          typename InterpolatorType,
-          typename ModelConfiguration,
-          typename FeaturesImageType>
+template <typename TImage, typename FeaturesMaps, typename InterpolatorType, typename FeaturesImageType>
 std::vector<FeaturesMaps>
 GetFeaturesMaps(
   typename TImage::ConstPointer                                                                    image,
   typename InterpolatorType::Pointer                                                               interpolator,
-  const std::vector<ModelConfiguration> &                                                          modelsConfiguration,
+  const std::vector<itk::ImpactModelConfiguration> &                                               modelsConfiguration,
   torch::Device                                                                                    device,
   std::vector<unsigned int>                                                                        pca,
   std::vector<torch::Tensor> &                                                                     principal_components,
@@ -545,11 +541,10 @@ GetFeaturesMaps(
 /**
  * **************** GetModelOutputsExample ****************
  */
-template <typename ModelConfiguration>
-std::vector<torch::Tensor>
-GetModelOutputsExample(std::vector<ModelConfiguration> & modelsConfig,
-                       const std::string &               modelType,
-                       torch::Device                     device)
+inline std::vector<torch::Tensor>
+GetModelOutputsExample(std::vector<itk::ImpactModelConfiguration> & modelsConfig,
+                       const std::string &                          modelType,
+                       torch::Device                                device)
 {
 
   std::vector<torch::Tensor> outputsTensor;
@@ -629,9 +624,8 @@ GetModelOutputsExample(std::vector<ModelConfiguration> & modelsConfig,
 /**
  * ******************* GetPatchIndex ***********************
  */
-template <typename ModelConfiguration>
-std::vector<std::vector<float>>
-GetPatchIndex(ModelConfiguration modelConfiguration, std::mt19937 & randomGenerator, unsigned int dimension)
+inline std::vector<std::vector<float>>
+GetPatchIndex(itk::ImpactModelConfiguration modelConfiguration, std::mt19937 & randomGenerator, unsigned int dimension)
 {
   if (dimension == modelConfiguration.GetPatchSize().size())
   {
@@ -696,9 +690,9 @@ GetPatchIndex(ModelConfiguration modelConfiguration, std::mt19937 & randomGenera
 /**
  * ******************* GenerateOutputs ***********************
  */
-template <typename ModelConfiguration, typename ImagePointType>
+template <typename ImagePointType>
 std::vector<torch::Tensor>
-GenerateOutputs(const std::vector<ModelConfiguration> &                               modelConfig,
+GenerateOutputs(const std::vector<itk::ImpactModelConfiguration> &                    modelConfig,
                 const std::vector<ImagePointType> &                                   fixedPoints,
                 const std::vector<std::vector<std::vector<std::vector<float>>>> &     patchIndex,
                 const std::vector<torch::Tensor>                                      subsetsOfFeatures,
@@ -758,9 +752,9 @@ GenerateOutputs(const std::vector<ModelConfiguration> &                         
 /**
  * ******************* GenerateOutputsAndJacobian ***********************
  */
-template <typename ModelConfiguration, typename ImagePointType>
+template <typename ImagePointType>
 std::vector<torch::Tensor>
-GenerateOutputsAndJacobian(const std::vector<ModelConfiguration> &                           modelConfig,
+GenerateOutputsAndJacobian(const std::vector<itk::ImpactModelConfiguration> &                modelConfig,
                            const std::vector<ImagePointType> &                               fixedPoints,
                            const std::vector<std::vector<std::vector<std::vector<float>>>> & patchIndex,
                            std::vector<torch::Tensor>                                        subsetsOfFeatures,

--- a/Components/Metrics/Impact/elxImpactMetric.h
+++ b/Components/Metrics/Impact/elxImpactMetric.h
@@ -258,7 +258,7 @@ protected:
 private:
   elxOverrideGetSelfMacro;
 
-  std::vector<typename Superclass1::ModelConfiguration>
+  std::vector<itk::ImpactModelConfiguration>
   GenerateModelsConfiguration(unsigned int level, std::string type, std::string mode, unsigned int imageDimension);
 };
 

--- a/Components/Metrics/Impact/elxImpactMetric.hxx
+++ b/Components/Metrics/Impact/elxImpactMetric.hxx
@@ -80,13 +80,13 @@ ImpactMetric<TElastix>::Initialize()
  * ******************* GenerateModelsConfiguration ***********************
  */
 template <typename TElastix>
-std::vector<typename ImpactMetric<TElastix>::Superclass1::ModelConfiguration>
+std::vector<itk::ImpactModelConfiguration>
 ImpactMetric<TElastix>::GenerateModelsConfiguration(unsigned int level,
                                                     std::string  prefix,
                                                     std::string  mode,
                                                     unsigned int imageDimension)
 {
-  std::vector<typename ImpactMetric<TElastix>::Superclass1::ModelConfiguration> modelsConfiguration;
+  std::vector<itk::ImpactModelConfiguration> modelsConfiguration;
 
   /** Get and set the model path. */
   std::string modelsPathStr;

--- a/Components/Metrics/Impact/itkImpactImageToImageMetric.h
+++ b/Components/Metrics/Impact/itkImpactImageToImageMetric.h
@@ -22,36 +22,16 @@
 #include "itkAdvancedImageToImageMetric.h"
 #include "itkBSplineInterpolateImageFunction.h"
 #include "itkBSplineInterpolateVectorImageFunction.h"
+#include "itkImpactModelConfiguration.h"
 #include "ImpactTensorUtils.h"
 #include "ImpactLoss.h"
 
 #include <torch/script.h>
 #include <torch/torch.h>
+
 #include <string>
 #include <vector>
 #include <random>
-#include <algorithm>
-
-/**
- * ******************* GetStringFromVector ***********************
- */
-template <typename T>
-std::string
-GetStringFromVector(const std::vector<T> & vec)
-{
-  std::stringstream ss;
-  ss << "(";
-  for (int i = 0; i < vec.size(); ++i)
-  {
-    ss << vec[i];
-    if (i != vec.size() - 1)
-    {
-      ss << " ";
-    }
-  }
-  ss << ")";
-  return ss.str();
-} // end GetStringFromVector
 
 namespace itk
 {
@@ -196,165 +176,17 @@ public:
   void
   Initialize() override;
 
-  /**
-   * Configuration structure for a TorchScript model used to extract semantic features.
-   *
-   * Contains path to the model, number of input channels, patch size and voxel size,
-   * along with internal buffers (e.g., precomputed patch index and center extraction index).
-   * If the mode is not static, the patchIndex is generated here to optimize runtime computation.
-   */
-  struct ModelConfiguration
-  {
-  public:
-    ModelConfiguration(std::string               modelPath,
-                       unsigned int              dimension,
-                       unsigned int              numberOfChannels,
-                       std::vector<unsigned int> patchSize,
-                       std::vector<float>        voxelSize,
-                       std::vector<bool>         layersMask,
-                       bool                      is_static)
-      : m_modelPath(modelPath)
-      , m_dimension(dimension)
-      , m_numberOfChannels(numberOfChannels)
-      , m_voxelSize(voxelSize)
-      , m_layersMask(layersMask)
-    {
-      this->m_patchSize = std::vector<int64_t>(patchSize.size());
-      std::transform(patchSize.begin(), patchSize.end(), this->m_patchSize.begin(), [](unsigned int val) {
-        return static_cast<int64_t>(val);
-      });
-      ;
-      this->m_model =
-        std::make_shared<torch::jit::script::Module>(torch::jit::load(this->m_modelPath, torch::Device(torch::kCPU)));
-      this->m_model->eval();
-      this->m_model->to(torch::kFloat);
-      if (!is_static)
-      {
-        /** Initialize some variables precalculation for loop performance */
-        this->m_patchIndex.clear();
-        if (this->m_patchSize.size() == 2)
-        {
-          for (int y = 0; y < this->m_patchSize[1]; ++y)
-          {
-            for (int x = 0; x < this->m_patchSize[0]; ++x)
-            {
-              this->m_patchIndex.push_back({ (x - this->m_patchSize[0] / 2) * this->m_voxelSize[0],
-                                             (y - this->m_patchSize[1] / 2) * this->m_voxelSize[1] });
-            }
-          }
-        }
-        else
-        {
-          for (int z = 0; z < this->m_patchSize[2]; ++z)
-          {
-            for (int y = 0; y < this->m_patchSize[1]; ++y)
-            {
-              for (int x = 0; x < this->m_patchSize[0]; ++x)
-              {
-                this->m_patchIndex.push_back({ (x - this->m_patchSize[0] / 2) * this->m_voxelSize[0],
-                                               (y - this->m_patchSize[1] / 2) * this->m_voxelSize[1],
-                                               (z - this->m_patchSize[2] / 2) * this->m_voxelSize[2] });
-              }
-            }
-          }
-        }
-      }
-    }
-
-    bool
-    operator==(const ModelConfiguration & rhs) const
-    {
-      return m_modelPath == rhs.m_modelPath && m_dimension == rhs.m_dimension &&
-             m_numberOfChannels == rhs.m_numberOfChannels && m_patchSize == rhs.m_patchSize &&
-             m_voxelSize == rhs.m_voxelSize && m_layersMask == rhs.m_layersMask;
-    }
-
-    friend std::ostream &
-    operator<<(std::ostream & os, const ModelConfiguration & config)
-    {
-      os << "\t\tPath : " << config.m_modelPath << "\n\t\tDimension : " << config.m_dimension
-         << "\n\t\tNumberOfChannels : " << config.m_numberOfChannels
-         << "\n\t\tPatchSize : " << GetStringFromVector<int64_t>(config.m_patchSize)
-         << "\n\t\tVoxelSize : " << GetStringFromVector<float>(config.m_voxelSize)
-         << "\n\t\tLayersMask : " << GetStringFromVector<bool>(config.m_layersMask);
-      return os;
-    }
-
-    const std::string &
-    GetModelPath() const
-    {
-      return m_modelPath;
-    }
-    unsigned int
-    GetDimension() const
-    {
-      return m_dimension;
-    }
-    unsigned int
-    GetNumberOfChannels() const
-    {
-      return m_numberOfChannels;
-    }
-    const std::vector<int64_t> &
-    GetPatchSize() const
-    {
-      return m_patchSize;
-    }
-    const std::vector<float> &
-    GetVoxelSize() const
-    {
-      return m_voxelSize;
-    }
-    const std::vector<bool> &
-    GetLayersMask() const
-    {
-      return m_layersMask;
-    }
-    const std::shared_ptr<torch::jit::script::Module> &
-    GetModel() const
-    {
-      return m_model;
-    }
-    const std::vector<std::vector<float>> &
-    GetPatchIndex() const
-    {
-      return m_patchIndex;
-    }
-    const std::vector<std::vector<torch::indexing::TensorIndex>> &
-    GetCentersIndexLayers() const
-    {
-      return m_centersIndexLayers;
-    }
-    void
-    SetCentersIndexLayers(std::vector<std::vector<torch::indexing::TensorIndex>> & centersIndexLayers)
-    {
-      this->m_centersIndexLayers = centersIndexLayers;
-    }
-
-  private:
-    std::string                                            m_modelPath;
-    unsigned int                                           m_dimension;
-    unsigned int                                           m_numberOfChannels;
-    std::vector<int64_t>                                   m_patchSize;
-    std::vector<float>                                     m_voxelSize;
-    std::vector<bool>                                      m_layersMask;
-    std::shared_ptr<torch::jit::script::Module>            m_model;
-    std::vector<std::vector<float>>                        m_patchIndex;
-    std::vector<std::vector<torch::indexing::TensorIndex>> m_centersIndexLayers;
-  };
-
-
   /** Set/Get the list of TorchScript model configurations used to extract features from the fixed image.
    * Each model can target a different resolution, architecture, or semantic level.
    */
-  itkSetMacro(FixedModelsConfiguration, std::vector<ModelConfiguration>);
-  itkGetConstMacro(FixedModelsConfiguration, std::vector<ModelConfiguration>);
+  itkSetMacro(FixedModelsConfiguration, std::vector<ImpactModelConfiguration>);
+  itkGetConstMacro(FixedModelsConfiguration, std::vector<ImpactModelConfiguration>);
 
   /** Set/Get the list of TorchScript model configurations used to extract features from the moving image.
    * Allows using different models for fixed and moving images to support asymmetric or multimodal setups.
    */
-  itkSetMacro(MovingModelsConfiguration, std::vector<ModelConfiguration>);
-  itkGetConstMacro(MovingModelsConfiguration, std::vector<ModelConfiguration>);
+  itkSetMacro(MovingModelsConfiguration, std::vector<ImpactModelConfiguration>);
+  itkGetConstMacro(MovingModelsConfiguration, std::vector<ImpactModelConfiguration>);
 
   /** Set/Get the subset of feature indices to be used in the loss computation.
    * This allows dimensionality reduction or focusing on the most informative channels.
@@ -711,14 +543,14 @@ private:
    */
   template <typename ImagePointType>
   std::vector<ImagePointType>
-  GeneratePatchIndex(const std::vector<ModelConfiguration> &                     modelConfig,
+  GeneratePatchIndex(const std::vector<ImpactModelConfiguration> &               modelConfig,
                      std::mt19937 &                                              randomGenerator,
                      const std::vector<ImagePointType> &                         fixedPointsTmp,
                      std::vector<std::vector<std::vector<std::vector<float>>>> & patchIndex) const;
 
   /** TorchScript model configurations for fixed and moving image feature extraction. */
-  std::vector<ModelConfiguration> m_FixedModelsConfiguration;
-  std::vector<ModelConfiguration> m_MovingModelsConfiguration;
+  std::vector<ImpactModelConfiguration> m_FixedModelsConfiguration;
+  std::vector<ImpactModelConfiguration> m_MovingModelsConfiguration;
 
   std::vector<unsigned int> m_SubsetFeatures;
   std::vector<unsigned int> m_PCA;

--- a/Components/Metrics/Impact/itkImpactImageToImageMetric.hxx
+++ b/Components/Metrics/Impact/itkImpactImageToImageMetric.hxx
@@ -87,8 +87,8 @@ ImpactImageToImageMetric<TFixedImage, TMovingImage>::UpdateFeaturesMaps()
       }
     });
 
-  this->m_movingFeaturesMaps = ImpactTensorUtils::
-    GetFeaturesMaps<TMovingImage, FeaturesMaps, InterpolatorType, ModelConfiguration, FeaturesImageType>(
+  this->m_movingFeaturesMaps =
+    ImpactTensorUtils::GetFeaturesMaps<TMovingImage, FeaturesMaps, InterpolatorType, FeaturesImageType>(
       Superclass::m_MovingImage,
       Superclass::m_Interpolator,
       this->GetMovingModelsConfiguration(),
@@ -97,8 +97,8 @@ ImpactImageToImageMetric<TFixedImage, TMovingImage>::UpdateFeaturesMaps()
       this->m_principal_components,
       this->GetWriteFeatureMaps() ? movingWriter : nullptr);
 
-  this->m_fixedFeaturesMaps = ImpactTensorUtils::
-    GetFeaturesMaps<TFixedImage, FeaturesMaps, InterpolatorType, ModelConfiguration, FeaturesImageType>(
+  this->m_fixedFeaturesMaps =
+    ImpactTensorUtils::GetFeaturesMaps<TFixedImage, FeaturesMaps, InterpolatorType, FeaturesImageType>(
       Superclass::m_FixedImage,
       this->m_fixedInterpolator,
       this->GetFixedModelsConfiguration(),
@@ -171,8 +171,8 @@ ImpactImageToImageMetric<TFixedImage, TMovingImage>::UpdateMovingFeaturesMaps()
     });
 
   this->m_movingFeaturesMaps.clear();
-  this->m_movingFeaturesMaps = ImpactTensorUtils::
-    GetFeaturesMaps<TMovingImage, FeaturesMaps, InterpolatorType, ModelConfiguration, FeaturesImageType>(
+  this->m_movingFeaturesMaps =
+    ImpactTensorUtils::GetFeaturesMaps<TMovingImage, FeaturesMaps, InterpolatorType, FeaturesImageType>(
       Superclass::m_MovingImage,
       Superclass::m_Interpolator,
       this->GetMovingModelsConfiguration(),
@@ -252,10 +252,10 @@ ImpactImageToImageMetric<TFixedImage, TMovingImage>::Initialize()
   }
   else
   {
-    std::vector<torch::Tensor> fixedOutputsTensor = ImpactTensorUtils::GetModelOutputsExample<ModelConfiguration>(
-      this->m_FixedModelsConfiguration, "fixed", this->GetDevice());
-    std::vector<torch::Tensor> movingOutputsTensor = ImpactTensorUtils::GetModelOutputsExample<ModelConfiguration>(
-      this->m_MovingModelsConfiguration, "moving", this->GetDevice());
+    std::vector<torch::Tensor> fixedOutputsTensor =
+      ImpactTensorUtils::GetModelOutputsExample(this->m_FixedModelsConfiguration, "fixed", this->GetDevice());
+    std::vector<torch::Tensor> movingOutputsTensor =
+      ImpactTensorUtils::GetModelOutputsExample(this->m_MovingModelsConfiguration, "moving", this->GetDevice());
 
     if (fixedOutputsTensor.size() != movingOutputsTensor.size())
     {
@@ -354,7 +354,7 @@ template <typename TFixedImage, typename TMovingImage>
 template <typename ImagePointType>
 std::vector<ImagePointType>
 ImpactImageToImageMetric<TFixedImage, TMovingImage>::GeneratePatchIndex(
-  const std::vector<ModelConfiguration> &                     modelConfig,
+  const std::vector<ImpactModelConfiguration> &               modelConfig,
   std::mt19937 &                                              randomGenerator,
   const std::vector<ImagePointType> &                         fixedPointsTmp,
   std::vector<std::vector<std::vector<std::vector<float>>>> & patchIndex) const
@@ -369,7 +369,7 @@ ImpactImageToImageMetric<TFixedImage, TMovingImage>::GeneratePatchIndex(
     for (int it = 0; it < fixedPointsTmp.size(); ++it)
     {
       std::vector<std::vector<float>> patch =
-        ImpactTensorUtils::GetPatchIndex<ModelConfiguration>(modelConfig[i], randomGenerator, FixedImageDimension);
+        ImpactTensorUtils::GetPatchIndex(modelConfig[i], randomGenerator, FixedImageDimension);
       if (this->SampleCheck(fixedPointsTmp[it], patch))
       {
         patchIndex[i].push_back(patch);
@@ -545,13 +545,12 @@ ImpactImageToImageMetric<TFixedImage, TMovingImage>::ComputeValue(
     };
 
 
-  fixedOutputsTensor =
-    ImpactTensorUtils::GenerateOutputs<ModelConfiguration, FixedImagePointType>(this->GetFixedModelsConfiguration(),
-                                                                                fixedPoints,
-                                                                                patchIndex,
-                                                                                subsetsOfFeatures,
-                                                                                this->GetDevice(),
-                                                                                fixedimagesPatchValuesEvaluator);
+  fixedOutputsTensor = ImpactTensorUtils::GenerateOutputs<FixedImagePointType>(this->GetFixedModelsConfiguration(),
+                                                                               fixedPoints,
+                                                                               patchIndex,
+                                                                               subsetsOfFeatures,
+                                                                               this->GetDevice(),
+                                                                               fixedimagesPatchValuesEvaluator);
 
   const ImpactTensorUtils::ImagesPatchValuesEvaluator<FixedImagePointType> movingimagesPatchValuesEvaluator =
     [this](const MovingImagePointType &            fixedImageCenterCoordinateLoc,
@@ -560,8 +559,7 @@ ImpactImageToImageMetric<TFixedImage, TMovingImage>::ComputeValue(
       return this->EvaluateMovingImagesPatchValue(fixedImageCenterCoordinateLoc, patchIndexLoc, patchSizeLoc);
     };
 
-  movingOutputsTensor =
-    ImpactTensorUtils::GenerateOutputs<ModelConfiguration, MovingImagePointType>(this->GetMovingModelsConfiguration(),
+  movingOutputsTensor = ImpactTensorUtils::GenerateOutputs<MovingImagePointType>(this->GetMovingModelsConfiguration(),
                                                                                  fixedPoints,
                                                                                  patchIndex,
                                                                                  subsetsOfFeatures,
@@ -682,13 +680,12 @@ ImpactImageToImageMetric<TFixedImage, TMovingImage>::ComputeValueAndDerivativeJa
     };
 
   std::vector<torch::Tensor> fixedOutputsTensor, movingOutputsTensor;
-  fixedOutputsTensor =
-    ImpactTensorUtils::GenerateOutputs<ModelConfiguration, FixedImagePointType>(this->GetFixedModelsConfiguration(),
-                                                                                fixedPoints,
-                                                                                patchIndex,
-                                                                                subsetsOfFeatures,
-                                                                                this->GetDevice(),
-                                                                                imagesPatchValuesEvaluator);
+  fixedOutputsTensor = ImpactTensorUtils::GenerateOutputs<FixedImagePointType>(this->GetFixedModelsConfiguration(),
+                                                                               fixedPoints,
+                                                                               patchIndex,
+                                                                               subsetsOfFeatures,
+                                                                               this->GetDevice(),
+                                                                               imagesPatchValuesEvaluator);
 
 
   const ImpactTensorUtils::ImagesPatchValuesAndJacobiansEvaluator<MovingImagePointType>
@@ -702,15 +699,14 @@ ImpactImageToImageMetric<TFixedImage, TMovingImage>::ComputeValueAndDerivativeJa
     };
 
   std::vector<torch::Tensor> layersJacobian =
-    ImpactTensorUtils::GenerateOutputsAndJacobian<ModelConfiguration, MovingImagePointType>(
-      this->GetMovingModelsConfiguration(),
-      fixedPoints,
-      patchIndex,
-      subsetsOfFeatures,
-      fixedOutputsTensor,
-      this->GetDevice(),
-      loss.m_losses,
-      imagesPatchValuesAndJacobiansEvaluator);
+    ImpactTensorUtils::GenerateOutputsAndJacobian<MovingImagePointType>(this->GetMovingModelsConfiguration(),
+                                                                        fixedPoints,
+                                                                        patchIndex,
+                                                                        subsetsOfFeatures,
+                                                                        fixedOutputsTensor,
+                                                                        this->GetDevice(),
+                                                                        loss.m_losses,
+                                                                        imagesPatchValuesAndJacobiansEvaluator);
 
   for (int i = 0; i < fixedOutputsTensor.size(); ++i)
   {

--- a/Components/Metrics/Impact/itkImpactModelConfiguration.h
+++ b/Components/Metrics/Impact/itkImpactModelConfiguration.h
@@ -1,0 +1,205 @@
+/*=========================================================================
+ *
+ *  Copyright UMC Utrecht and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkImpactModelConfiguration_h
+#define itkImpactModelConfiguration_h
+
+#include <torch/script.h>
+#include <torch/torch.h>
+
+// Standard C++ header files:
+#include <algorithm> // For transform.
+#include <memory>    // For shared_ptr.
+#include <sstream>
+#include <string>
+#include <vector>
+
+/**
+ * ******************* GetStringFromVector ***********************
+ */
+template <typename T>
+std::string
+GetStringFromVector(const std::vector<T> & vec)
+{
+  std::stringstream ss;
+  ss << "(";
+  for (int i = 0; i < vec.size(); ++i)
+  {
+    ss << vec[i];
+    if (i != vec.size() - 1)
+    {
+      ss << " ";
+    }
+  }
+  ss << ")";
+  return ss.str();
+} // end GetStringFromVector
+
+
+namespace itk
+{
+/**
+ * Configuration structure for a TorchScript model used to extract semantic features.
+ *
+ * Contains path to the model, number of input channels, patch size and voxel size,
+ * along with internal buffers (e.g., precomputed patch index and center extraction index).
+ * If the mode is not static, the patchIndex is generated here to optimize runtime computation.
+ */
+struct ImpactModelConfiguration
+{
+public:
+  ImpactModelConfiguration(std::string               modelPath,
+                           unsigned int              dimension,
+                           unsigned int              numberOfChannels,
+                           std::vector<unsigned int> patchSize,
+                           std::vector<float>        voxelSize,
+                           std::vector<bool>         layersMask,
+                           bool                      is_static)
+    : m_modelPath(modelPath)
+    , m_dimension(dimension)
+    , m_numberOfChannels(numberOfChannels)
+    , m_voxelSize(voxelSize)
+    , m_layersMask(layersMask)
+  {
+    this->m_patchSize = std::vector<int64_t>(patchSize.size());
+    std::transform(patchSize.begin(), patchSize.end(), this->m_patchSize.begin(), [](unsigned int val) {
+      return static_cast<int64_t>(val);
+    });
+    ;
+    this->m_model =
+      std::make_shared<torch::jit::script::Module>(torch::jit::load(this->m_modelPath, torch::Device(torch::kCPU)));
+    this->m_model->eval();
+    this->m_model->to(torch::kFloat);
+    if (!is_static)
+    {
+      /** Initialize some variables precalculation for loop performance */
+      this->m_patchIndex.clear();
+      if (this->m_patchSize.size() == 2)
+      {
+        for (int y = 0; y < this->m_patchSize[1]; ++y)
+        {
+          for (int x = 0; x < this->m_patchSize[0]; ++x)
+          {
+            this->m_patchIndex.push_back({ (x - this->m_patchSize[0] / 2) * this->m_voxelSize[0],
+                                           (y - this->m_patchSize[1] / 2) * this->m_voxelSize[1] });
+          }
+        }
+      }
+      else
+      {
+        for (int z = 0; z < this->m_patchSize[2]; ++z)
+        {
+          for (int y = 0; y < this->m_patchSize[1]; ++y)
+          {
+            for (int x = 0; x < this->m_patchSize[0]; ++x)
+            {
+              this->m_patchIndex.push_back({ (x - this->m_patchSize[0] / 2) * this->m_voxelSize[0],
+                                             (y - this->m_patchSize[1] / 2) * this->m_voxelSize[1],
+                                             (z - this->m_patchSize[2] / 2) * this->m_voxelSize[2] });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  bool
+  operator==(const ImpactModelConfiguration & rhs) const
+  {
+    return m_modelPath == rhs.m_modelPath && m_dimension == rhs.m_dimension &&
+           m_numberOfChannels == rhs.m_numberOfChannels && m_patchSize == rhs.m_patchSize &&
+           m_voxelSize == rhs.m_voxelSize && m_layersMask == rhs.m_layersMask;
+  }
+
+  friend std::ostream &
+  operator<<(std::ostream & os, const ImpactModelConfiguration & config)
+  {
+    os << "\t\tPath : " << config.m_modelPath << "\n\t\tDimension : " << config.m_dimension
+       << "\n\t\tNumberOfChannels : " << config.m_numberOfChannels
+       << "\n\t\tPatchSize : " << GetStringFromVector<int64_t>(config.m_patchSize)
+       << "\n\t\tVoxelSize : " << GetStringFromVector<float>(config.m_voxelSize)
+       << "\n\t\tLayersMask : " << GetStringFromVector<bool>(config.m_layersMask);
+    return os;
+  }
+
+  const std::string &
+  GetModelPath() const
+  {
+    return m_modelPath;
+  }
+  unsigned int
+  GetDimension() const
+  {
+    return m_dimension;
+  }
+  unsigned int
+  GetNumberOfChannels() const
+  {
+    return m_numberOfChannels;
+  }
+  const std::vector<int64_t> &
+  GetPatchSize() const
+  {
+    return m_patchSize;
+  }
+  const std::vector<float> &
+  GetVoxelSize() const
+  {
+    return m_voxelSize;
+  }
+  const std::vector<bool> &
+  GetLayersMask() const
+  {
+    return m_layersMask;
+  }
+  const std::shared_ptr<torch::jit::script::Module> &
+  GetModel() const
+  {
+    return m_model;
+  }
+  const std::vector<std::vector<float>> &
+  GetPatchIndex() const
+  {
+    return m_patchIndex;
+  }
+  const std::vector<std::vector<torch::indexing::TensorIndex>> &
+  GetCentersIndexLayers() const
+  {
+    return m_centersIndexLayers;
+  }
+  void
+  SetCentersIndexLayers(std::vector<std::vector<torch::indexing::TensorIndex>> & centersIndexLayers)
+  {
+    this->m_centersIndexLayers = centersIndexLayers;
+  }
+
+private:
+  std::string                                            m_modelPath;
+  unsigned int                                           m_dimension;
+  unsigned int                                           m_numberOfChannels;
+  std::vector<int64_t>                                   m_patchSize;
+  std::vector<float>                                     m_voxelSize;
+  std::vector<bool>                                      m_layersMask;
+  std::shared_ptr<torch::jit::script::Module>            m_model;
+  std::vector<std::vector<float>>                        m_patchIndex;
+  std::vector<std::vector<torch::indexing::TensorIndex>> m_centersIndexLayers;
+};
+
+} // end namespace itk
+
+#endif // end #ifndef itkImpactModelConfiguration_h


### PR DESCRIPTION
Moved `ModelConfiguration` from inside `ImpactImageToImageMetric<TFixedImage, TMovingImage>` into its own header file, `itkImpactModelConfiguration.h`, and renamed it to `ImpactModelConfiguration`.

Aims to simplify the design, by expressing that there is just one ModelConfiguration type for the IMPACT metric, independent of the types `TFixedImage` and `TMovingImage`.