### PR TITLE
Use range-based `for` loops, simplify m_patchSize initialization

### DIFF
--- a/Components/Metrics/Impact/ImpactTensorUtils.hxx
+++ b/Components/Metrics/Impact/ImpactTensorUtils.hxx
@@ -601,17 +601,16 @@ GetModelOutputsExample(std::vector<itk::ImpactModelConfiguration> & modelsConfig
         }
       }
     }
-    for (int i = 0; i < modelsConfig.size(); ++i)
+    for (itk::ImpactModelConfiguration & config : modelsConfig)
     {
-      auto &                                                 config = modelsConfig[i];
       std::vector<std::vector<torch::indexing::TensorIndex>> centersIndexLayers;
-      for (int it = 0; it < outputsTensor.size(); ++it)
+      for (const torch::Tensor & tensor : outputsTensor)
       {
         std::vector<torch::indexing::TensorIndex> centersIndexLayer;
         centersIndexLayer.push_back("...");
-        for (int j = 2; j < outputsTensor[it].dim(); ++j)
+        for (int j = 2; j < tensor.dim(); ++j)
         {
-          centersIndexLayer.push_back(outputsTensor[it].size(j) / 2);
+          centersIndexLayer.push_back(tensor.size(j) / 2);
         }
         centersIndexLayers.push_back(centersIndexLayer);
       }

--- a/Components/Metrics/Impact/itkBSplineInterpolateVectorImageFunction.hxx
+++ b/Components/Metrics/Impact/itkBSplineInterpolateVectorImageFunction.hxx
@@ -48,9 +48,9 @@ BSplineInterpolateVectorImageFunction<TImage, TInterpolator>::Evaluate(typename 
                                                                        std::vector<unsigned int> subsetOfFeatures) const
 {
   std::vector<float> result;
-  for (int i = 0; i < subsetOfFeatures.size(); ++i)
+  for (const unsigned int feature : subsetOfFeatures)
   {
-    result.push_back(this->m_Interpolators[subsetOfFeatures[i]]->Evaluate(point));
+    result.push_back(this->m_Interpolators[feature]->Evaluate(point));
   }
   return torch::from_blob(result.data(), { static_cast<int64_t>(result.size()) }, torch::kFloat).clone();
 }

--- a/Components/Metrics/Impact/itkImpactImageToImageMetric.hxx
+++ b/Components/Metrics/Impact/itkImpactImageToImageMetric.hxx
@@ -322,11 +322,11 @@ ImpactImageToImageMetric<TFixedImage, TMovingImage>::SampleCheck(
 {
   FixedImagePointType  fixedImagePoint(fixedImageCenterCoordinate);
   MovingImagePointType mappedPoint;
-  for (int i = 0; i < patchIndex.size(); ++i)
+  for (const std::vector<float> & patchIndexItem : patchIndex)
   {
-    for (int dim = 0; dim < patchIndex[i].size(); ++dim)
+    for (int dim = 0; dim < patchIndexItem.size(); ++dim)
     {
-      fixedImagePoint[dim] = fixedImageCenterCoordinate[dim] + patchIndex[i][dim];
+      fixedImagePoint[dim] = fixedImageCenterCoordinate[dim] + patchIndexItem[dim];
     }
     mappedPoint = this->TransformPoint(fixedImagePoint);
     if (Superclass::m_Interpolator->IsInsideBuffer(mappedPoint) == false)

--- a/Components/Metrics/Impact/itkImpactModelConfiguration.h
+++ b/Components/Metrics/Impact/itkImpactModelConfiguration.h
@@ -73,14 +73,10 @@ public:
     : m_modelPath(modelPath)
     , m_dimension(dimension)
     , m_numberOfChannels(numberOfChannels)
+    , m_patchSize(patchSize.begin(), patchSize.end())
     , m_voxelSize(voxelSize)
     , m_layersMask(layersMask)
   {
-    this->m_patchSize = std::vector<int64_t>(patchSize.size());
-    std::transform(patchSize.begin(), patchSize.end(), this->m_patchSize.begin(), [](unsigned int val) {
-      return static_cast<int64_t>(val);
-    });
-    ;
     this->m_model =
       std::make_shared<torch::jit::script::Module>(torch::jit::load(this->m_modelPath, torch::Device(torch::kCPU)));
     this->m_model->eval();


### PR DESCRIPTION
Just a few very small C++ style suggestions.

The range-based `for` loops were suggested by clang-tidy: https://clang.llvm.org/extra/clang-tidy/checks/modernize/loop-convert.html