### PR TITLE
Avoid copying `ImpactModelConfiguration`, let `GetModel()` return a reference

### DIFF
--- a/Components/Metrics/Impact/ImpactTensorUtils.h
+++ b/Components/Metrics/Impact/ImpactTensorUtils.h
@@ -99,7 +99,9 @@ GetModelOutputsExample(std::vector<itk::ImpactModelConfiguration> & modelsConfig
  * This is used to extract local neighborhoods for each model (e.g., 5x5x5 patch).
  */
 std::vector<std::vector<float>>
-GetPatchIndex(itk::ImpactModelConfiguration modelConfiguration, std::mt19937 & randomGenerator, unsigned int dimension);
+GetPatchIndex(const itk::ImpactModelConfiguration & modelConfiguration,
+              std::mt19937 &                        randomGenerator,
+              unsigned int                          dimension);
 
 template <typename ImagePointType>
 using ImagesPatchValuesEvaluator = std::function<

--- a/Components/Metrics/Impact/ImpactTensorUtils.hxx
+++ b/Components/Metrics/Impact/ImpactTensorUtils.hxx
@@ -625,7 +625,9 @@ GetModelOutputsExample(std::vector<itk::ImpactModelConfiguration> & modelsConfig
  * ******************* GetPatchIndex ***********************
  */
 inline std::vector<std::vector<float>>
-GetPatchIndex(itk::ImpactModelConfiguration modelConfiguration, std::mt19937 & randomGenerator, unsigned int dimension)
+GetPatchIndex(const itk::ImpactModelConfiguration & modelConfiguration,
+              std::mt19937 &                        randomGenerator,
+              unsigned int                          dimension)
 {
   if (dimension == modelConfiguration.GetPatchSize().size())
   {

--- a/Components/Metrics/Impact/ImpactTensorUtils.hxx
+++ b/Components/Metrics/Impact/ImpactTensorUtils.hxx
@@ -380,7 +380,7 @@ GetFeaturesMaps(
                                          .repeat({ torch::IntArrayRef(channelRepeat) })
                                          .unsqueeze(0)
                                          .to(device);
-            std::vector<torch::jit::IValue> outputsPatch = config.GetModel()->forward({ inputPatch }).toList().vec();
+            std::vector<torch::jit::IValue> outputsPatch = config.GetModel().forward({ inputPatch }).toList().vec();
 
 
             if (config.GetLayersMask().size() != outputsPatch.size())
@@ -455,7 +455,7 @@ GetFeaturesMaps(
                                        .unsqueeze(0)
                                        .to(device);
 
-          std::vector<torch::jit::IValue> outputsPatch = config.GetModel()->forward({ inputPatch }).toList().vec();
+          std::vector<torch::jit::IValue> outputsPatch = config.GetModel().forward({ inputPatch }).toList().vec();
 
           if (config.GetLayersMask().size() != outputsPatch.size())
           {
@@ -564,7 +564,7 @@ GetModelOutputsExample(std::vector<itk::ImpactModelConfiguration> & modelsConfig
                           .to(device);
       try
       {
-        outputsList = config.GetModel()->forward({ modelInput }).toList().vec();
+        outputsList = config.GetModel().forward({ modelInput }).toList().vec();
       }
       catch (const std::exception & e)
       {
@@ -730,7 +730,7 @@ GenerateOutputs(const std::vector<itk::ImpactModelConfiguration> &              
       resizeVector[1] = config.GetNumberOfChannels();
       std::vector<torch::jit::IValue> outputsList =
         config.GetModel()
-          ->forward({ patchValueTensor.to(device).repeat({ torch::IntArrayRef(resizeVector) }).clone() })
+          .forward({ patchValueTensor.to(device).repeat({ torch::IntArrayRef(resizeVector) }).clone() })
           .toList()
           .vec();
 
@@ -800,7 +800,7 @@ GenerateOutputsAndJacobian(const std::vector<itk::ImpactModelConfiguration> &   
       patchValueTensor.to(device).repeat({ torch::IntArrayRef(resizeVector) }).clone().set_requires_grad(true);
     imagesPatchesJacobians = imagesPatchesJacobians.to(device).repeat({ 1, config.GetNumberOfChannels(), 1 }).clone();
 
-    std::vector<torch::jit::IValue> outputsList = config.GetModel()->forward({ patchValueTensor }).toList().vec();
+    std::vector<torch::jit::IValue> outputsList = config.GetModel().forward({ patchValueTensor }).toList().vec();
     torch::Tensor                   layer, diffLayer, modelJacobian;
     for (int it = 0; it < outputsList.size(); ++it)
     {

--- a/Components/Metrics/Impact/elxImpactMetric.hxx
+++ b/Components/Metrics/Impact/elxImpactMetric.hxx
@@ -341,7 +341,7 @@ ImpactMetric<TElastix>::BeforeEachResolution()
   {
     std::vector<bool> layersMask = this->GetFixedModelsConfiguration()[i].GetLayersMask();
     fixedNumberOfLayers += std::count(layersMask.begin(), layersMask.end(), true);
-    this->GetFixedModelsConfiguration()[i].GetModel()->to(this->GetDevice());
+    this->GetFixedModelsConfiguration()[i].GetModel().to(this->GetDevice());
   }
 
   int movingNumberOfLayers = 0;
@@ -349,7 +349,7 @@ ImpactMetric<TElastix>::BeforeEachResolution()
   {
     std::vector<bool> layersMask = this->GetMovingModelsConfiguration()[i].GetLayersMask();
     movingNumberOfLayers += std::count(layersMask.begin(), layersMask.end(), true);
-    this->GetMovingModelsConfiguration()[i].GetModel()->to(this->GetDevice());
+    this->GetMovingModelsConfiguration()[i].GetModel().to(this->GetDevice());
   }
 
   if (fixedNumberOfLayers != movingNumberOfLayers)

--- a/Components/Metrics/Impact/itkImpactImageToImageMetric.h
+++ b/Components/Metrics/Impact/itkImpactImageToImageMetric.h
@@ -180,13 +180,13 @@ public:
    * Each model can target a different resolution, architecture, or semantic level.
    */
   itkSetMacro(FixedModelsConfiguration, std::vector<ImpactModelConfiguration>);
-  itkGetConstMacro(FixedModelsConfiguration, std::vector<ImpactModelConfiguration>);
+  itkGetConstReferenceMacro(FixedModelsConfiguration, std::vector<ImpactModelConfiguration>);
 
   /** Set/Get the list of TorchScript model configurations used to extract features from the moving image.
    * Allows using different models for fixed and moving images to support asymmetric or multimodal setups.
    */
   itkSetMacro(MovingModelsConfiguration, std::vector<ImpactModelConfiguration>);
-  itkGetConstMacro(MovingModelsConfiguration, std::vector<ImpactModelConfiguration>);
+  itkGetConstReferenceMacro(MovingModelsConfiguration, std::vector<ImpactModelConfiguration>);
 
   /** Set/Get the subset of feature indices to be used in the loss computation.
    * This allows dimensionality reduction or focusing on the most informative channels.

--- a/Components/Metrics/Impact/itkImpactModelConfiguration.h
+++ b/Components/Metrics/Impact/itkImpactModelConfiguration.h
@@ -180,10 +180,10 @@ public:
   {
     return m_layersMask;
   }
-  const std::shared_ptr<torch::jit::script::Module> &
+  torch::jit::script::Module &
   GetModel() const
   {
-    return m_model;
+    return *m_model;
   }
   const std::vector<std::vector<float>> &
   GetPatchIndex() const

--- a/Components/Metrics/Impact/itkImpactModelConfiguration.h
+++ b/Components/Metrics/Impact/itkImpactModelConfiguration.h
@@ -118,6 +118,19 @@ public:
     }
   }
 
+  // Disable (delete) copying, to avoid having multiple copies of the same model:
+  ImpactModelConfiguration(const ImpactModelConfiguration &) = delete;
+  ImpactModelConfiguration &
+  operator=(const ImpactModelConfiguration &) = delete;
+
+  // Enable (default) move semantics:
+  ImpactModelConfiguration(ImpactModelConfiguration &&) = default;
+  ImpactModelConfiguration &
+  operator=(ImpactModelConfiguration &&) = default;
+
+  // Destructor.
+  ~ImpactModelConfiguration() = default;
+
   bool
   operator==(const ImpactModelConfiguration & rhs) const
   {


### PR DESCRIPTION
Multiple copies of an `ImpactModelConfiguration` would share the same model, which could be confusing, especially when the model is being modified.

It might also be slightly more efficient to pass a `ImpactModelConfiguration` object "by const reference", instead of "by value".

Also let `ImpactModelConfiguration::GetModel()` return a reference, instead of a `shared_ptr`. Aims to express that the model returned by GetModel() is owned and managed by an `ImpactModelConfiguration`. So the lifetime of the model should not be extended beyond the lifetime of the `ImpactModelConfiguration`.